### PR TITLE
Refine index.astro page styles

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,4 @@
----
+import Layout from "../layouts/Layout.astro"
 import { client } from "../lib/sanity"
 const posts = await client.fetch(`
   *[_type=="post"] | order(publishedAt desc)[0..9]{
@@ -7,19 +7,26 @@ const posts = await client.fetch(`
 `)
 ---
 
-<html lang="ja">
-  <body>
-    <h1>最新記事</h1>
-    <ul>
-      {posts.map((p:any)=>(
-        <li>
-          <a href={`/blog/${p.slug}`}>{p.title}</a>
-          <small>{new Date(p.publishedAt).toLocaleDateString('ja-JP')}</small>
-          <p>{p.excerpt}</p>
-        </li>
-      ))}
-    </ul>
+<Layout title="ホーム" addTitleSuffix={true} description="最新記事">
+  <main class="px-4 sm:px-6 py-10">
+    <section class="mx-auto max-w-7xl">
+      <h1 class="text-3xl sm:text-4xl font-black">最新記事</h1>
+      <ul class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((p:any)=>(
+          <li class="card card-border bg-base-100 shadow-sm transition hover:shadow-md">
+            <a class="block p-5" href={`/blog/${p.slug}`}>
+              <h3 class="text-lg font-bold line-clamp-2">{p.title}</h3>
+              <div class="mt-2 text-xs text-base-content/60">{new Date(p.publishedAt).toLocaleDateString('ja-JP')}</div>
+              {p.excerpt && <p class="mt-3 text-sm text-base-content/80 line-clamp-3">{p.excerpt}</p>}
+            </a>
+          </li>
+        ))}
+      </ul>
 
-    <p><a href="/blog">→ すべてのブログ記事</a></p>
-  </body>
-</html>
+      <div class="mt-8 text-right">
+        <a class="btn btn-primary btn-sm sm:btn-md" href="/blog">→ すべてのブログ記事</a>
+      </div>
+    </section>
+  </main>
+  
+</Layout>


### PR DESCRIPTION
Apply Tailwind/DaisyUI styles and `Layout.astro` to `src/pages/index.astro` to create a responsive grid of post cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a122e6e-f121-4483-b734-f4c0a2ecf814">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a122e6e-f121-4483-b734-f4c0a2ecf814">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

